### PR TITLE
D-40706 Fix cluster-install RR upgrade issue.

### DIFF
--- a/xl-infra/blueprint.yaml
+++ b/xl-infra/blueprint.yaml
@@ -75,7 +75,7 @@ spec:
       type: Select
       prompt: !expr "'Product server you want to perform ' + ProcessType + ' for:'"
       options:
-        - label: Digital.ai Release with optional Digital.ai Release Runner
+        - label: Digital.ai Release
           value: dai-release
         - label: Digital.ai Deploy
           value: dai-deploy

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -1550,7 +1550,8 @@ spec:
           0.0:
           23.3: .
         .spec.ssl: .
-        .spec.hooks: .
+        .spec.hooks.genSelfSigned: .
+        .spec.hooks.getLicense: .
         .spec.centralConfiguration.configuration: .
         .spec.centralConfiguration.extraConfiguration: .
         .spec.centralConfiguration.diagnosticMode: .
@@ -1761,7 +1762,8 @@ spec:
           23.3: .
         .spec.http2.enabled: .
         .spec.ssl: .
-        .spec.hooks: .
+        .spec.hooks.genSelfSigned: .
+        .spec.hooks.getLicense: .
         .spec.configuration: .
         .spec.extraConfiguration: .
         .spec.postgresql.primary.configuration: .


### PR DESCRIPTION
i) Rename server to just Digital.ai Release since Runner is optional and only for install not upgrade ii) Exclude .spec.hooks.installReleaseRunner from PreserveCrValuesRelease & Deploy so its not preserved during upgrade, when its enabled during cluster-install.