### PR TITLE
S-132502 Updated postgresql and rabbitmq promptIf fields to include proper ServerType

### DIFF
--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -1095,7 +1095,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Provide Storage Class to be defined for PostgreSQL:"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
+      promptIf: !expr "ServerType != 'dai-release-runner' && (ProcessType == 'install' || ProcessType == 'upgrade') && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
       description: |
         Provide Storage Class to be defined for PostgreSQL that should be available in the cluster.
         The storage class needs to support minimally ReadWriteOnce access mode.
@@ -1105,7 +1105,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Provide PVC size for PostgreSQL (Gi):"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
+      promptIf: !expr "ServerType != 'dai-release-runner' && (ProcessType == 'install' || ProcessType == 'upgrade') && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
       default: 8
       description: Provide PVC size for PostgreSQL
       validate: !expr "regex('^([0-9])+(\\.)?([0-9])*$', PostgresqlPvcSize)"
@@ -1130,7 +1130,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Select one of the predefined resource values for Postgresql:"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'preset' && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
+      promptIf: !expr "ServerType != 'dai-release-runner' && (ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'preset' && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
       description: "Select one of the predefined resource values for Postgresql"
       default: micro
     - name: PostgresqlResourcesEditor
@@ -1139,7 +1139,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Provide resource allocation for Postgresql:"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'editor' && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
+      promptIf: !expr "ServerType != 'dai-release-runner' && (ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'editor' && (PostgresqlType == 'chart' || PostgresqlType == 'operator')"
       description: "Provide resource allocation (requests and limits values) for Postgresql"
       default: !expr DefaultResourcesEditor
     - name: PostgresqlExternalConfigRelease
@@ -1225,7 +1225,7 @@ spec:
       overrideDefault: true
       prompt: "Replica count to be defined for RabbitMQ:"
       default: 3
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
+      promptIf: !expr "ServerType == 'dai-deploy' && (ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
       description: "Replica count to be defined for RabbitMQ"
       validate: !expr "regex('^([1-9])+$', RabbitmqReplicaCount)"
     - name: RabbitmqStorageClass
@@ -1237,7 +1237,7 @@ spec:
       overrideDefault: true
       prompt: "Storage Class to be defined for RabbitMQ:"
       default: !expr StorageClass
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
+      promptIf: !expr "ServerType == 'dai-deploy' && (ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
       description: |
         Storage Class to be defined for RabbitMQ.
         The storage class needs to support minimally ReadWriteOnce access mode.
@@ -1248,7 +1248,7 @@ spec:
       overrideDefault: true
       prompt: "Provide PVC size for RabbitMQ (Gi):"
       default: 8
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
+      promptIf: !expr "ServerType == 'dai-deploy' && (ProcessType == 'install' || ProcessType == 'upgrade') && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
       description: Provide PVC size for RabbitMQ
       validate: !expr "regex('^([0-9])+(\\.)?([0-9])*$', RabbitmqPvcSize)"
     - name: RabbitmqResourcesPreset
@@ -1272,7 +1272,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Select one of the predefined resource values for Rabbitmq:"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'preset' && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
+      promptIf: !expr "ServerType == 'dai-deploy' && (ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'preset' && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
       description: "Select one of the predefined resource values for Rabbitmq"
       default: micro
     - name: RabbitmqResourcesEditor
@@ -1281,7 +1281,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Provide resource allocation for Rabbitmq:"
-      promptIf: !expr "(ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'editor' && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
+      promptIf: !expr "ServerType == 'dai-deploy' && (ProcessType == 'install' || ProcessType == 'upgrade') && ResourcesSource == 'editor' && (RabbitmqType == 'chart' || RabbitmqType == 'operator')"
       description: "Provide resource allocation (requests and limits values) for Rabbitmq"
       default: !expr DefaultResourcesEditor
     - name: RabbitmqExternalConfigDeploy


### PR DESCRIPTION
With runner cluster-install with answers, without proper server type, The promptIf fields are wrongly evaluating to true. 
Now with updated server type, they will rightly evaluate to false. 